### PR TITLE
Update domain list

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -6,7 +6,6 @@
   "namecheap.com",
   "iwantmyname.com",
   "enom.com",
-  "ovhcloud.com",
   "ionos.com",
   "ionos.co.uk",
   "123-reg.com",
@@ -20,5 +19,6 @@
   "godaddy.co.uk",
   "hostinger.com",
   "hostinger.co.uk",
-  "20i.com"
+  "20i.com",
+  "cosmotown.com"
 ]


### PR DESCRIPTION
Ovhcloud removed since it's not only a domain host, but rather entire cloud, redirecting would be annoying.

We should consider making redirect website configurable, google isn't very privacy friendly search engine.
(copied from original pr)