### PR TITLE
Dynamic Update Functionality Added

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
     "48": "assets/icon48.png",
     "128": "assets/icon128.png"
   },
-  "permissions": ["declarativeNetRequestWithHostAccess"],
+  "permissions": ["declarativeNetRequestWithHostAccess","storage"],
   "host_permissions": ["*://*/*"],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; script-src-elem 'self'; object-src 'self'"


### PR DESCRIPTION
In Reference with issue no #33 

Added dynamic update functionality that checks for and updates the domains list everyday once.
Uses chrome's local storage to store the value of date when the update was previously done and compares with that date and decides whether to run the update or not