### PR TITLE
Add individual WhiteList entry deletion

### DIFF
--- a/assets/cross.svg
+++ b/assets/cross.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" 
+	viewBox="0 0 32.526 32.526"
+	style="color: white;">
+		<polygon style="fill: white" points="32.526,2.828 29.698,0 16.263,13.435 2.828,0 0,2.828 13.435,16.263 0,29.698 2.828,32.526 16.263,19.091 
+	29.698,32.526 32.526,29.698 19.091,16.263 "/>
+</svg>

--- a/assets/styles/options.css
+++ b/assets/styles/options.css
@@ -129,6 +129,7 @@ body {
 }
 
 #WhiteList_Erase_Button {
+    display: none;
     padding: 0.5em 1em;
     font-size: 1.2rem;
     font-weight: 600;
@@ -147,6 +148,7 @@ body {
 }
 
 #whiteList_domains_table {
+    display: none;
     margin-block: 1.5em;
 }
 

--- a/assets/styles/options.css
+++ b/assets/styles/options.css
@@ -128,6 +128,30 @@ body {
     margin-bottom: 0.5em;
 }
 
+.whitelist-ent-del-btn {
+    padding: 5px 9px;
+    font-weight: 600;
+    cursor: pointer;
+    background-color: #1e1e1e;
+    color: #da3633;
+    border: 1px solid #f0f6fc1a;
+    border-radius: 4px;
+    transition: all 0.15s ease;
+}
+
+.whitelist-ent-del-btn:hover {
+    background-color: #da3633;
+    border-color: #ff7b72;
+    color: #fff;
+}
+
+.whitelist-ent-del-btn>img {
+    position: relative;
+    top: -0.05em;
+    height: 7px;
+    width: 7px;
+}
+
 #WhiteList_Erase_Button {
     display: none;
     padding: 0.5em 1em;

--- a/options.js
+++ b/options.js
@@ -3,31 +3,31 @@ var Domain = document.getElementById("whiteListDomain");
 var Display_whiteList_Domains = document.getElementById("whiteList_domains");
 var Erase_Button = document.getElementById("WhiteList_Erase_Button");
 var whiteList_domains_table = document.getElementById("whiteList_domains_table");
-var whiteList_Memory = [];
+var whiteList_Memory = new Set();
 
 function addWhiteList() {
     // Store the user input into an array and update declarativeNetRequest Filters
     if(Domain.value!=undefined && Domain.value!=""){
-        whiteList_Memory.push(Domain.value);
+        whiteList_Memory.add(Domain.value);
 
         // Update whiteList_Memory variable with domains already exisitng in the local storage
         chrome.storage.local.get(['user_whitelist'], function (data) {
             if(data.user_whitelist!=undefined){
                 if(data.user_whitelist.length!=0){
-                    whiteList_Memory = [...whiteList_Memory, ...data.user_whitelist];
+                    whiteList_Memory = new Set([...whiteList_Memory, ...data.user_whitelist]);
                     console.log("Values already exists");
                     console.log(whiteList_Memory);
-                    chrome.storage.local.set({ "user_whitelist": whiteList_Memory });
+                    chrome.storage.local.set({ "user_whitelist": [...whiteList_Memory] });
                 }
                 else{
                     whiteList_Memory = [...whiteList_Memory];
-                    console.log("Values dosen't exists");
+                    console.log("Values doesn't exists");
                     console.log(whiteList_Memory);
-                    chrome.storage.local.set({ "user_whitelist": whiteList_Memory });
+                    chrome.storage.local.set({ "user_whitelist": [...whiteList_Memory] });
                 }
             }
         });
-        chrome.storage.local.set({ "user_whitelist": whiteList_Memory });
+        chrome.storage.local.set({ "user_whitelist": [...whiteList_Memory] });
         // Add decleartiveNetRequest rules beyond the rules already present by default in the extension 
         chrome.storage.local.get(['rules_count','user_whitelist'], function (result) {
             if(result.user_whitelist!=undefined){

--- a/options.js
+++ b/options.js
@@ -20,7 +20,7 @@ function addWhiteList() {
                     chrome.storage.local.set({ "user_whitelist": [...whiteList_Memory] });
                 }
                 else{
-                    whiteList_Memory = [...whiteList_Memory];
+                    whiteList_Memory = new Set([...whiteList_Memory]);
                     console.log("Values doesn't exists");
                     console.log(whiteList_Memory);
                     chrome.storage.local.set({ "user_whitelist": [...whiteList_Memory] });
@@ -112,7 +112,7 @@ function removeWhitelist(){
                 console.log(whiteList_Memory);
                 // Reset whilelist array
                 setTimeout(() => {
-                    whiteList_Memory.length = 0;
+                    whiteList_Memory.clear();
                     chrome.storage.local.remove(["user_whitelist"]);
                     alert("Whitelist Removed!");
                 }, 500);


### PR DESCRIPTION
## Description
This PR will add an individual WhiteList entry deletion feature to the extension's `/options` page. User will be able to delete specific whitelist domain from the full list of whitelist domains visible on the page. 

Closes: #78